### PR TITLE
Send current track details to connected devices, and two Bluetooth fixes

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -54,8 +54,7 @@
                 <action android:name="android.intent.action.BOOT_COMPLETED"/>
                 <action android:name="org.lyrion.squeezelite.START"/>
                 <action android:name="org.lyrion.squeezelite.STOP"/>
-                <action android:name="android.bluetooth.device.action.ACL_CONNECTED" />
-                <action android:name="android.bluetooth.device.action.ACL_DISCONNECTED" />
+                <action android:name="android.bluetooth.a2dp.profile.action.CONNECTION_STATE_CHANGED" />
             </intent-filter>
         </receiver>
 

--- a/android/app/src/main/java/org/lyrion/squeezelite/CommandReceiver.java
+++ b/android/app/src/main/java/org/lyrion/squeezelite/CommandReceiver.java
@@ -20,11 +20,14 @@
 
 package org.lyrion.squeezelite;
 
+import android.bluetooth.BluetoothA2dp;
 import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothProfile;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
+import android.os.SystemClock;
 
 import java.util.Set;
 
@@ -36,6 +39,9 @@ import java.util.Set;
 public class CommandReceiver extends BroadcastReceiver {
     private static final String START = "org.lyrion.squeezelite.START";
     private static final String STOP = "org.lyrion.squeezelite.STOP";
+    private static final long IGNORE_RECONNECT_AFTER = 5000;
+
+    private static long lastDisconnect = 0;
 
     @Override
     public void onReceive(Context context, Intent intent) {
@@ -49,40 +55,56 @@ public class CommandReceiver extends BroadcastReceiver {
             startOnBoot(context);
         } else if (act.equals(STOP)) {
             context.stopService(new Intent(context, PlayerService.class));
-        } else if (act.equals(BluetoothDevice.ACTION_ACL_CONNECTED) || act.equals(BluetoothDevice.ACTION_ACL_DISCONNECTED)) {
-            handleBtIntent(context, intent, act);
+        } else if (act.equals(BluetoothA2dp.ACTION_CONNECTION_STATE_CHANGED)) {
+            handleBtIntent(context, intent);
         }
     }
 
-    private void handleBtIntent(Context context, Intent intent, String act) {
+    private void handleBtIntent(Context context, Intent intent) {
         BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
-        if (device != null) {
-            String macAddress = device.getAddress();
-            Utils.debug("BT MAC address: " + macAddress);
+        if (device == null) {
+            return;
+        }
+        String macAddress = device.getAddress();
+        Utils.debug("BT MAC address: " + macAddress);
 
-            if (!Prefs.get(context).getBoolean(Prefs.AUTOSTART_BT_KEY, false)) {
-                Utils.debug("Not configured for BT auto-start");
-                return;
-            }
+        int state = intent.getIntExtra(BluetoothProfile.EXTRA_STATE, -1);
+        if (BluetoothProfile.STATE_CONNECTED != state && BluetoothProfile.STATE_DISCONNECTED != state) {
+            Utils.debug("Ignoring A2DP state " + state);
+            return;
+        }
+        boolean connected = BluetoothProfile.STATE_CONNECTED == state;
 
-            Set<String> macs = Prefs.get(context).getStringSet(Prefs.BT_MAC_ADDRESSES_KEY, null);
-            if (null==macs || macs.isEmpty()) {
-                Utils.debug("No BT MACs configured");
-                return;
-            }
+        if (!Prefs.get(context).getBoolean(Prefs.AUTOSTART_BT_KEY, false)) {
+            Utils.debug("Not configured for BT auto-start");
+            return;
+        }
 
-            if (!macs.contains(macAddress)) {
-                Utils.debug("Not a configured BT MAC");
-                return;
-            }
+        Set<String> macs = Prefs.get(context).getStringSet(Prefs.BT_MAC_ADDRESSES_KEY, null);
+        if (null==macs || macs.isEmpty()) {
+            Utils.debug("No BT MACs configured");
+            return;
+        }
 
-            if (Utils.isPlayerRunning(context)) {
-                context.stopService(new Intent(context, PlayerService.class));
-            }
+        if (!macs.contains(macAddress)) {
+            Utils.debug("Not a configured BT MAC");
+            return;
+        }
 
-            if (act.equals(BluetoothDevice.ACTION_ACL_CONNECTED)) {
-                startService(context);
-            }
+        long now = SystemClock.elapsedRealtime();
+        if (!connected) {
+            lastDisconnect = now;
+        } else if (now-lastDisconnect < IGNORE_RECONNECT_AFTER) {
+            Utils.debug("Ignoring a connection " + (now-lastDisconnect) + "ms after a disconnection");
+            return;
+        }
+
+        if (Utils.isPlayerRunning(context)) {
+            context.stopService(new Intent(context, PlayerService.class));
+        }
+
+        if (connected) {
+            startService(context);
         }
     }
 

--- a/android/app/src/main/java/org/lyrion/squeezelite/JsonRpc.java
+++ b/android/app/src/main/java/org/lyrion/squeezelite/JsonRpc.java
@@ -21,12 +21,15 @@
 package org.lyrion.squeezelite;
 
 import android.content.Context;
+import android.graphics.Bitmap;
+import android.widget.ImageView;
 
 import androidx.annotation.Nullable;
 
 import com.android.volley.DefaultRetryPolicy;
 import com.android.volley.RequestQueue;
 import com.android.volley.Response;
+import com.android.volley.toolbox.ImageRequest;
 import com.android.volley.toolbox.JsonObjectRequest;
 import com.android.volley.toolbox.Volley;
 
@@ -57,6 +60,23 @@ public class JsonRpc {
 
     public void setAddress(String address) {
         this.server = new ServerDiscovery.Server(address, ServerDiscovery.Server.DEFAULT_PORT, "");
+    }
+
+    public String getMac() {
+        return mac;
+    }
+
+    public String getBaseUrl() {
+        return "http://" + server.ip + ":" + server.port + "/";
+    }
+
+    public void fetchImage(String url, int maxSize, Response.Listener<Bitmap> listener) {
+        Utils.debug("URL:" + url);
+        requestQueue.add(new ImageRequest(url, listener, maxSize, maxSize, ImageView.ScaleType.CENTER_INSIDE,
+                Bitmap.Config.RGB_565, error -> {
+                    Utils.warn("Failed to fetch " + url);
+                    listener.onResponse(null);
+                }));
     }
 
     public void sendMessage(String[] command) {

--- a/android/app/src/main/java/org/lyrion/squeezelite/JsonRpc.java
+++ b/android/app/src/main/java/org/lyrion/squeezelite/JsonRpc.java
@@ -40,7 +40,12 @@ public class JsonRpc {
 
     private static class Request extends JsonObjectRequest {
         public Request(String url, @Nullable JSONObject request, Response.Listener<JSONObject> responseListener) {
-            super(Request.Method.POST, url, request, responseListener, null);
+            super(Request.Method.POST, url, request, responseListener, error -> {
+                Utils.warn("Request failed - " + error);
+                if (null!=responseListener) {
+                    responseListener.onResponse(null);
+                }
+            });
         }
     }
 

--- a/android/app/src/main/java/org/lyrion/squeezelite/Library.java
+++ b/android/app/src/main/java/org/lyrion/squeezelite/Library.java
@@ -66,10 +66,11 @@ public class Library {
     private long lmsVolumeSendTime;
     private int volumeControl = VOL_SEP;
     private int maxBitrate = 0;
+    private boolean forgetOnStop = false;
     private PlayerService service;
     private VolumeChangeObserver observer;
     private AudioManager audioManager;
-    private JsonRpc jsonRpc;
+    private volatile JsonRpc jsonRpc;
     private String ipAddress;
 
     private class VolumeChangeObserver extends ContentObserver {
@@ -150,9 +151,10 @@ public class Library {
             audioManager = (AudioManager) service.getSystemService(Context.AUDIO_SERVICE);
             androidMaxVolume = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC);
         }
+        jsonRpc = new JsonRpc(service, server, mac);
+        forgetOnStop = VOL_SYNC==volumeControl;
         if (VOL_SYNC==volumeControl) {
             androidVolume = UNKNOWN_VOL;
-            jsonRpc = new JsonRpc(service, server, mac);
             observer = new VolumeChangeObserver();
             service.getApplicationContext().getContentResolver().registerContentObserver(Settings.System.CONTENT_URI, true, observer);
         }
@@ -212,7 +214,7 @@ public class Library {
             Utils.error("Exception interrupting player thread", e);
         }
         thread = null;
-        if (null != jsonRpc) {
+        if (null != jsonRpc && forgetOnStop) {
             jsonRpc.sendMessage(new String[]{"client", "forget"}, response -> {
                 Utils.debug("Handle 'forget' resp");
                 System.exit(0);
@@ -342,8 +344,9 @@ public class Library {
     }
 
     public void sendCommand(String[] cmd) {
-        if (null!=jsonRpc) {
-            jsonRpc.sendMessage(cmd);
+        JsonRpc rpc = jsonRpc;
+        if (null!=rpc) {
+            rpc.sendMessage(cmd);
         }
     }
 

--- a/android/app/src/main/java/org/lyrion/squeezelite/Library.java
+++ b/android/app/src/main/java/org/lyrion/squeezelite/Library.java
@@ -23,6 +23,7 @@ package org.lyrion.squeezelite;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.database.ContentObserver;
+import android.graphics.Bitmap;
 import android.media.AudioManager;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
@@ -33,11 +34,18 @@ import android.provider.Settings;
 
 import androidx.annotation.Keep;
 
+import com.android.volley.Response;
+
+import org.json.JSONObject;
+
 
 public class Library {
     private static final String[] PREV_COMMAND = {"button", "jump_rew"};
+    private static final String[] PLAY_COMMAND = {"pause", "0"};
+    private static final String[] PAUSE_COMMAND = {"pause", "1"};
     private static final String[] TOGGLE_PLAY_PAUSE_COMMAND = {"pause"};
     private static final String[] NEXT_COMMAND = {"playlist", "index", "+1"};
+    private static final String[] STOP_COMMAND = {"stop"};
 
     // Timeout after which Squeezelite will close audio stream
     static final int STREAM_IDLE_TIMEOUT = 2000;
@@ -67,7 +75,7 @@ public class Library {
     private int volumeControl = VOL_SEP;
     private int maxBitrate = 0;
     private boolean forgetOnStop = false;
-    private PlayerService service;
+    private volatile PlayerService service;
     private VolumeChangeObserver observer;
     private AudioManager audioManager;
     private volatile JsonRpc jsonRpc;
@@ -331,8 +339,26 @@ public class Library {
         isInitialPower = false;
     }
 
+    // Called from C code when a track starts, or playback is paused, resumed, or stopped
+    @Keep
+    public void playbackStateChanged() {
+        Utils.debug("");
+        PlayerService svc = service;
+        if (null!=svc) {
+            svc.playbackStateChanged();
+        }
+    }
+
     public void prev() {
         sendCommand(PREV_COMMAND);
+    }
+
+    public void play() {
+        sendCommand(PLAY_COMMAND);
+    }
+
+    public void pause() {
+        sendCommand(PAUSE_COMMAND);
     }
 
     public void playPause() {
@@ -343,11 +369,41 @@ public class Library {
         sendCommand(NEXT_COMMAND);
     }
 
+    public void stopPlayback() {
+        sendCommand(STOP_COMMAND);
+    }
+
+    public void seekTo(long ms) {
+        sendCommand(new String[]{"time", String.valueOf(ms/1000.0)});
+    }
+
     public void sendCommand(String[] cmd) {
         JsonRpc rpc = jsonRpc;
         if (null!=rpc) {
             rpc.sendMessage(cmd);
         }
+    }
+
+    public void getStatus(String tags, Response.Listener<JSONObject> listener) {
+        if (null==jsonRpc) {
+            listener.onResponse(null);
+            return;
+        }
+        jsonRpc.sendMessage(new String[]{"status", "-", "1", tags}, listener);
+    }
+
+    public void fetchImage(String url, int maxSize, Response.Listener<Bitmap> listener) {
+        if (null!=jsonRpc) {
+            jsonRpc.fetchImage(url, maxSize, listener);
+        }
+    }
+
+    public String getServerUrl() {
+        return null==jsonRpc ? null : jsonRpc.getBaseUrl();
+    }
+
+    public String getMac() {
+        return null==jsonRpc ? null : jsonRpc.getMac();
     }
 
     private native void start(String lms, String mac, String name, int idleTimeout, int fixedVolume, int logging, int mobileNetwork, int streamBuffer);

--- a/android/app/src/main/java/org/lyrion/squeezelite/NowPlaying.java
+++ b/android/app/src/main/java/org/lyrion/squeezelite/NowPlaying.java
@@ -1,0 +1,269 @@
+/*
+ *  Squeezelite Android
+ *
+ *  (c) Craig Drummond 2025-2026 <craig.p.drummond@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.lyrion.squeezelite;
+
+import android.graphics.Bitmap;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.SystemClock;
+import android.support.v4.media.MediaMetadataCompat;
+import android.support.v4.media.session.MediaSessionCompat;
+import android.support.v4.media.session.PlaybackStateCompat;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * Reads the details of the track LMS is playing, and publishes these - with the playback
+ * state - into the MediaSession. Android relays an active session on to connected devices,
+ * e.g. as AVRCP metadata for a BT car stereo, and to Android Auto, the lock screen, etc.
+ */
+public class NowPlaying {
+    // artist, album, duration, coverid, artwork url, remote stream title, is-remote
+    private static final String TAGS = "tags:aldcKNx";
+    // Let LMS settle on the new track, and coalesce a burst of events into a single query
+    private static final long QUERY_DELAY = 250;
+    // If LMS still reports the previous track then try again after this long
+    private static final long RETRY_DELAY = 1500;
+    private static final int MAX_RETRIES = 2;
+    private static final long REMOTE_POLL_INTERVAL = 30000;
+    // Keep the artwork small enough to comfortably fit through a binder transaction
+    private static final int MAX_COVER_SIZE = 384;
+
+    private final Library lib;
+    private final MediaSessionCompat session;
+    private final Handler handler = new Handler(Looper.getMainLooper());
+    private final Runnable queryTask = this::query;
+    private final PlayerService service;
+
+    private boolean released = false;
+    private int retries = 0;
+    private String trackKey = null;
+    private int state = PlaybackStateCompat.STATE_NONE;
+    private boolean remoteStream = false;
+    private String coverUrl = null;
+    private Bitmap cover = null;
+    private MediaMetadataCompat.Builder metadata = null;
+    private String description = null;
+
+    public NowPlaying(PlayerService service, Library lib, MediaSessionCompat session) {
+        this.service = service;
+        this.lib = lib;
+        this.session = session;
+    }
+
+    public void update() {
+        if (released) {
+            return;
+        }
+        retries = MAX_RETRIES;
+        handler.removeCallbacks(queryTask);
+        handler.postDelayed(queryTask, QUERY_DELAY);
+    }
+
+    public void release() {
+        released = true;
+        handler.removeCallbacks(queryTask);
+        cover = null;
+        coverUrl = null;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    private void query() {
+        if (released) {
+            return;
+        }
+        lib.getStatus(TAGS, response -> {
+            if (!released) {
+                handleStatus(response);
+            }
+        });
+    }
+
+    private void handleStatus(JSONObject response) {
+        JSONObject result = null==response ? null : response.optJSONObject("result");
+        if (null==result) {
+            Utils.warn("No status received from server");
+            scheduleNext(true);
+            return;
+        }
+
+        String mode = result.optString("mode", "stop");
+        JSONArray loop = result.optJSONArray("playlist_loop");
+        JSONObject track = null!=loop && loop.length()>0 ? loop.optJSONObject(0) : null;
+
+        if (null==track || "stop".equals(mode)) {
+            remoteStream = false;
+            setStopped();
+            scheduleNext(false);
+            return;
+        }
+
+        boolean remote = 0!=track.optInt("remote", 0);
+        String title = firstOf(track, "title");
+        String artist = firstOf(track, "artist", "trackartist", "albumartist", "artist_name");
+        // For a remote stream 'album' is not set, but remote_title names the station
+        String album = remote ? firstOf(track, "remote_title") : firstOf(track, "album");
+        if (remote && (Utils.isEmpty(title) || title.equals(artist))) {
+            // Not every station sends usable metadata - one was seen putting the same changing
+            // number in both title and artist. The station name is all LMS always knows.
+            title = album;
+            artist = "";
+        }
+        // Per-track for local files, but the status itself is better for remote streams
+        double duration = track.optDouble("duration", result.optDouble("duration", 0));
+        double time = result.optDouble("time", 0);
+        String url = coverUrl(track);
+
+        // No artwork URL here - LMS mints a fresh coverid for a remote stream on every request,
+        // so that would make each poll of a webradio look like a new track
+        String key = title + " " + artist + " " + album + " " + duration;
+        int newState = "play".equals(mode) ? PlaybackStateCompat.STATE_PLAYING : PlaybackStateCompat.STATE_PAUSED;
+        boolean trackChanged = !key.equals(trackKey);
+        boolean stateChanged = newState!=state;
+        remoteStream = remote && PlaybackStateCompat.STATE_PLAYING==newState;
+
+        if (trackChanged) {
+            Utils.debug("New track:" + title + " - " + artist);
+            trackKey = key;
+            metadata = new MediaMetadataCompat.Builder()
+                    .putString(MediaMetadataCompat.METADATA_KEY_TITLE, title)
+                    .putString(MediaMetadataCompat.METADATA_KEY_DISPLAY_TITLE, title)
+                    .putString(MediaMetadataCompat.METADATA_KEY_ARTIST, artist)
+                    .putString(MediaMetadataCompat.METADATA_KEY_DISPLAY_SUBTITLE, artist)
+                    .putString(MediaMetadataCompat.METADATA_KEY_ALBUM, album)
+                    .putLong(MediaMetadataCompat.METADATA_KEY_DURATION, (long)(duration*1000));
+            description = Utils.isEmpty(artist) ? title : (title + " - " + artist);
+            if (!url.equals(coverUrl)) {
+                coverUrl = url;
+                cover = null;
+                fetchCover(url);
+            }
+            publishMetadata();
+            service.trackChanged();
+        }
+
+        setState(newState, (long)(time*1000));
+        scheduleNext(!trackChanged && !stateChanged);
+    }
+
+    // 'stale' means nothing new was reported, which after a player event usually means LMS has
+    // not caught up with it yet. A remote stream needs polling regardless - its songs follow
+    // one another without the player ever starting a new track, so there is no event for them.
+    private void scheduleNext(boolean stale) {
+        long delay = 0;
+        if (!stale) {
+            // The retry budget belongs to the event we were waiting for, which is now settled -
+            // without this the 'nothing changed' answers of a webradio poll would spend it
+            retries = 0;
+        }
+        if (stale && retries>0) {
+            retries--;
+            delay = RETRY_DELAY;
+        } else if (remoteStream) {
+            delay = REMOTE_POLL_INTERVAL;
+        }
+        handler.removeCallbacks(queryTask);
+        if (delay>0 && !released) {
+            handler.postDelayed(queryTask, delay);
+        }
+    }
+
+    private void setStopped() {
+        Utils.debug("");
+        boolean changed = null!=trackKey;
+        trackKey = null;
+        description = null;
+        setState(PlaybackStateCompat.STATE_STOPPED, 0);
+        if (changed) {
+            service.trackChanged();
+        }
+    }
+
+    private void setState(int state, long position) {
+        this.state = state;
+        session.setPlaybackState(new PlaybackStateCompat.Builder()
+                .setActions(PlaybackStateCompat.ACTION_PLAY | PlaybackStateCompat.ACTION_PAUSE |
+                            PlaybackStateCompat.ACTION_PLAY_PAUSE | PlaybackStateCompat.ACTION_STOP |
+                            PlaybackStateCompat.ACTION_SKIP_TO_NEXT |
+                            PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS |
+                            PlaybackStateCompat.ACTION_SEEK_TO)
+                .setState(state, position, PlaybackStateCompat.STATE_PLAYING==state ? 1.0f : 0.0f,
+                          SystemClock.elapsedRealtime())
+                .build());
+    }
+
+    private void publishMetadata() {
+        if (null==metadata) {
+            return;
+        }
+        session.setMetadata(metadata.putBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART, cover)
+                                    .putBitmap(MediaMetadataCompat.METADATA_KEY_ART, cover)
+                                    .build());
+    }
+
+    private void fetchCover(String url) {
+        if (Utils.isEmpty(url)) {
+            return;
+        }
+        lib.fetchImage(url, MAX_COVER_SIZE, bitmap -> {
+            // Only use this if it is still the cover we are interested in
+            if (!released && null!=bitmap && url.equals(coverUrl)) {
+                cover = bitmap;
+                // Only the session carries the artwork, so the notification needs no rebuild
+                publishMetadata();
+            }
+        });
+    }
+
+    private String coverUrl(JSONObject track) {
+        String base = lib.getServerUrl();
+        if (null==base) {
+            return "";
+        }
+        // artwork_url before coverid - a remote stream gets a stable artwork_url, but a
+        // synthetic coverid that changes on every request. Local tracks only have a coverid.
+        String url = track.optString("artwork_url", "");
+        if (!Utils.isEmpty(url)) {
+            return url.startsWith("http") ? url : (base + (url.startsWith("/") ? url.substring(1) : url));
+        }
+        String coverId = track.optString("coverid", "");
+        if (!Utils.isEmpty(coverId)) {
+            return base + "music/" + coverId + "/cover.jpg";
+        }
+        // Fall back to whatever LMS thinks this player's current cover is
+        String mac = lib.getMac();
+        return Utils.isEmpty(mac) ? "" : (base + "music/current/cover.jpg?player=" + mac);
+    }
+
+    private static String firstOf(JSONObject obj, String... keys) {
+        for (String key : keys) {
+            String val = obj.optString(key, "");
+            if (!Utils.isEmpty(val)) {
+                return val;
+            }
+        }
+        return "";
+    }
+}

--- a/android/app/src/main/java/org/lyrion/squeezelite/PlayerService.java
+++ b/android/app/src/main/java/org/lyrion/squeezelite/PlayerService.java
@@ -72,6 +72,7 @@ public class PlayerService extends Service {
     private String playerName;
     private MediaSessionCompat mediaSession;
     private MediaSessionCompat.Callback mediaSessionCallback;
+    private volatile NowPlaying nowPlaying;
 
     public PlayerService() {
         handler = new Handler(Looper.getMainLooper());
@@ -176,11 +177,13 @@ public class PlayerService extends Service {
             Intent quitIntent = new Intent(this, PlayerService.class);
             quitIntent.setAction(QUIT_INTENT);
 
+            String track = null==nowPlaying ? null : nowPlaying.getDescription();
             notificationBuilder
                     .setOngoing(true)
                     .setOnlyAlertOnce(true)
                     .setSmallIcon(R.drawable.ic_mono_icon)
                     .setContentTitle(name + (Utils.isEmpty(currentServerAddress) ? "" : (" (" + currentServerAddress +")")))
+                    .setContentText(track)
                     .setCategory(Notification.CATEGORY_SERVICE)
                     .setContentIntent(pendingIntent)
                     .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
@@ -255,7 +258,7 @@ public class PlayerService extends Service {
                 public void onPlay() {
                     Utils.debug("");
                     if (null!=lib) {
-                        lib.playPause();
+                        lib.play();
                     }
                 }
 
@@ -263,7 +266,15 @@ public class PlayerService extends Service {
                 public void onPause() {
                     Utils.debug("");
                     if (null!=lib) {
-                        lib.playPause();
+                        lib.pause();
+                    }
+                }
+
+                @Override
+                public void onStop() {
+                    Utils.debug("");
+                    if (null!=lib) {
+                        lib.stopPlayback();
                     }
                 }
 
@@ -282,33 +293,37 @@ public class PlayerService extends Service {
 
                 @Override
                 public void onSeekTo(long pos) {
-                    //sendCommand(new String[]{"time", Double.toString(pos/1000.0)});
+                    if (null!=lib) {
+                        lib.seekTo(pos);
+                    }
                 }
 
+                // Act on ACTION_DOWN, and consume it, so that the event does not also reach the
+                // transport callbacks above. ACTION_UP falls through to super, which ignores it.
+                @Override
                 public boolean onMediaButtonEvent(Intent mediaButtonEvent) {
-                    Utils.debug("");
                     KeyEvent event = mediaButtonEvent.getParcelableExtra(Intent.EXTRA_KEY_EVENT);
-                    if (lib!=null && event!=null && 1==event.getAction()) {
+                    if (null!=lib && null!=event && KeyEvent.ACTION_DOWN==event.getAction()) {
                         Utils.debug("KeyCode:" + event.getKeyCode());
                         switch (event.getKeyCode()) {
                             case KeyEvent.KEYCODE_MEDIA_PLAY:
-                                Utils.debug("Play");
-                                lib.playPause();
+                                lib.play();
                                 return true;
                             case KeyEvent.KEYCODE_MEDIA_PAUSE:
-                                Utils.debug("Pause");
-                                lib.playPause();
+                                lib.pause();
                                 return true;
+                            case KeyEvent.KEYCODE_MEDIA_STOP:
+                                lib.stopPlayback();
+                                return true;
+                            // These do not say which of the two is wanted, so toggle
                             case KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE:
-                                Utils.debug("Play/pause");
+                            case KeyEvent.KEYCODE_HEADSETHOOK:
                                 lib.playPause();
                                 return true;
                             case KeyEvent.KEYCODE_MEDIA_PREVIOUS:
-                                Utils.debug("Prev");
                                 lib.prev();
                                 return true;
                             case KeyEvent.KEYCODE_MEDIA_NEXT:
-                                Utils.debug("Next");
                                 lib.next();
                                 return true;
                             default:
@@ -321,6 +336,13 @@ public class PlayerService extends Service {
         }
         mediaSession.setFlags(MediaSessionCompat.FLAG_HANDLES_MEDIA_BUTTONS | MediaSessionCompat.FLAG_HANDLES_TRANSPORT_CONTROLS);
         mediaSession.setCallback(mediaSessionCallback);
+        if (Prefs.get(this).getBoolean(Prefs.SEND_TRACK_DETAILS_KEY, Prefs.DEFAULT_SEND_TRACK_DETAILS)) {
+            // Only activate the session when there is something to publish - Android will not
+            // relay its contents to connected devices otherwise
+            mediaSession.setActive(true);
+            nowPlaying = new NowPlaying(this, lib, mediaSession);
+            nowPlaying.update();
+        }
     }
 
     private void stopPlayer() {
@@ -333,11 +355,27 @@ public class PlayerService extends Service {
         }
         sendStatus(false);
         stopTerminateTimer();
+        if (null!=nowPlaying) {
+            nowPlaying.release();
+            nowPlaying = null;
+        }
         lib.stopPlayer(this);
         if (mediaSession != null) {
             mediaSession.setActive(false);
             mediaSession.release();
         }
+    }
+
+    public void playbackStateChanged() {
+        Utils.debug("");
+        NowPlaying np = nowPlaying;
+        if (null!=np) {
+            handler.post(np::update);
+        }
+    }
+
+    public void trackChanged() {
+        updateNotification();
     }
 
     private void sendStatus(boolean running) {
@@ -363,6 +401,8 @@ public class PlayerService extends Service {
             startTerminateTimer(connectionLostTimeout);
         } else {
             stopTerminateTimer();
+            // Now that we know where the server is, read what it is playing
+            playbackStateChanged();
         }
     }
 

--- a/android/app/src/main/java/org/lyrion/squeezelite/Prefs.java
+++ b/android/app/src/main/java/org/lyrion/squeezelite/Prefs.java
@@ -51,6 +51,7 @@ public class Prefs {
     public static final String AUTOSTART_BT_KEY = "autostart_bt";
     public static final String BT_MAC_ADDRESSES_KEY = "bt_mac_addresses";
     public static final String USE_BT_ID_KEY = "use_bt_id";
+    public static final String SEND_TRACK_DETAILS_KEY = "send_track_details";
     public static int MAX_BITRATE_ALWAYS = 0;
     public static int MAX_BITRATE_WHEN_CELLULAR = 1;
     public static int MAX_BITRATE_WHEN_METERED = 2;
@@ -72,6 +73,7 @@ public class Prefs {
     public static boolean DEFAULT_START_ON_BOOT = false;
     public static String DEFAULT_START_ON_BOOT_DELAY = "0";
     public static boolean DEFAULT_STOP_ON_POWER_OFF = true;
+    public static boolean DEFAULT_SEND_TRACK_DETAILS = true;
 
     static public SharedPreferences get(Context context) {
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
@@ -172,6 +174,12 @@ public class Prefs {
                 editor = sharedPreferences.edit();
             }
             editor.putBoolean(STOP_ON_POWER_OFF_KEY, DEFAULT_STOP_ON_POWER_OFF);
+        }
+        if (!sharedPreferences.contains(SEND_TRACK_DETAILS_KEY)) {
+            if (null==editor) {
+                editor = sharedPreferences.edit();
+            }
+            editor.putBoolean(SEND_TRACK_DETAILS_KEY, DEFAULT_SEND_TRACK_DETAILS);
         }
         if (editor!=null) {
             editor.apply();

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -41,6 +41,8 @@
     <string name="autostart_bt">Démarrer la platine à la connexion</string>
     <string name="autostart_bt_summary">Lorsqu\'un des appareils Bluetooth configurés se connecte, démarre la platine en utilisant son ID et son nom.</string>
     <string name="bt_mac_addresses">Démarrage auto à la connexion de l\'appareil</string>
+    <string name="send_track_details">Envoyer les infos du morceau</string>
+    <string name="send_track_details_summary">Envoie les informations du morceau en cours (titre, artiste, album, pochette) à l\'appareil connecté, afin qu\'il puisse les afficher. Également utilisé pour l\'écran de verrouillage et Android Auto.</string>
     <string name="use_bt_id">Utiliser l\'ID et le nom</string>
     <string name="use_bt_id_summary">Utilise le nom et l\'ID de l\'appareil connecté comme nom et ID sur le serveur Lyrion.</string>
     <string name="none">Aucun</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -41,6 +41,8 @@
     <string name="autostart_bt">Start player on connect</string>
     <string name="autostart_bt_summary">When one of the configured BT devices connects then start player using its ID and name.</string>
     <string name="bt_mac_addresses">Auto start when device connects</string>
+    <string name="send_track_details">Send track details</string>
+    <string name="send_track_details_summary">Send details of the track being played (title, artist, album, artwork) to the connected device, so that it can display these. Also used for the lock screen and Android Auto.</string>
     <string name="use_bt_id">Use ID and name</string>
     <string name="use_bt_id_summary">Use name and ID of connected device as name and ID on Lyrion server.</string>
     <string name="none">None</string>

--- a/android/app/src/main/res/xml/root_preferences.xml
+++ b/android/app/src/main/res/xml/root_preferences.xml
@@ -148,6 +148,12 @@
             app:singleLineTitle="false"/>
         <SwitchPreferenceCompat
             app:iconSpaceReserved="false"
+            app:key="send_track_details"
+            app:summary="@string/send_track_details_summary"
+            app:title="@string/send_track_details"
+            app:singleLineTitle="false"/>
+        <SwitchPreferenceCompat
+            app:iconSpaceReserved="false"
             app:key="autostart_bt"
             app:summary="@string/autostart_bt_summary"
             app:title="@string/autostart_bt"

--- a/android/src/android.c
+++ b/android/src/android.c
@@ -101,6 +101,32 @@ void send_volume_to_app(u32_t left, u32_t right) {
 	}
 }
 
+void send_playback_state_to_app(void) {
+	if (!jvm || !obj || !clazz) {
+		return;
+	}
+	JNIEnv *env;
+	bool detached = JNI_EDETACHED == (*jvm)->GetEnv(jvm, &env, JNI_VERSION_1_6);
+	if (detached) {
+		if (JNI_OK!=(*jvm)->AttachCurrentThread(jvm, &env, NULL)) {
+			LOG_ERROR("Failed to get attach current thread");
+			return;
+		}
+	}
+	jmethodID method = (*env)->GetMethodID(env, clazz, "playbackStateChanged", "()V");
+	if (method) {
+		(*env)->CallVoidMethod(env, obj, method);
+	} else {
+		// A failed GetMethodID leaves an exception pending, and the next JNI call from this
+		// thread would then abort the VM. Happens if the native library is newer than the java.
+		(*env)->ExceptionClear(env);
+		LOG_ERROR("playbackStateChanged not found");
+	}
+	if (detached) {
+		(*jvm)->DetachCurrentThread(jvm);
+	}
+}
+
 void send_connection_state_to_app(const char *address) {
 	if (!jvm || !obj || !clazz) {
 		return;

--- a/slimproto.c
+++ b/slimproto.c
@@ -293,6 +293,9 @@ static void process_strm(u8_t *pkt, int len) {
 		stream_disconnect();
 		sendSTAT("STMf", 0);
 		buf_flush(streambuf);
+#ifdef ANDROID
+		send_playback_state_to_app();
+#endif
 		break;
 	case 'f': 
 		{
@@ -319,6 +322,9 @@ static void process_strm(u8_t *pkt, int len) {
 			UNLOCK_O;
 			if (!interval) sendSTAT("STMp", 0);
 			LOG_DEBUG("pause interval: %u", interval);
+#ifdef ANDROID
+			if (!interval) send_playback_state_to_app();
+#endif
 		}
 		break;
 	case 'a':
@@ -341,6 +347,9 @@ static void process_strm(u8_t *pkt, int len) {
 
 			LOG_DEBUG("unpause at: %u now: %u", jiffies, gettime_ms());
 			sendSTAT("STMr", 0);
+#ifdef ANDROID
+			send_playback_state_to_app();
+#endif
 		}
 		break;
 	case 's':
@@ -760,7 +769,13 @@ static void slimproto_run() {
 
 			// send packets once locks released as packet sending can block
 			if (_sendDSCO) sendDSCO(disconnect_code);
-			if (_sendSTMs) sendSTAT("STMs", 0);
+			if (_sendSTMs) {
+				sendSTAT("STMs", 0);
+#ifdef ANDROID
+				// A new track has started playing - let the app update its MediaSession
+				send_playback_state_to_app();
+#endif
+			}
 			if (_sendSTMd) sendSTAT("STMd", 0);
 			if (_sendSTMt) sendSTAT("STMt", 0);
 			if (_sendSTMl) sendSTAT("STMl", 0);

--- a/squeezelite.h
+++ b/squeezelite.h
@@ -478,6 +478,7 @@ typedef enum { lERROR = 0, lWARN, lINFO, lDEBUG, lSDEBUG } log_level;
 extern void send_output_state_to_app(u8_t spdif, u8_t dac);
 extern void send_volume_to_app(u32_t left, u32_t right);
 extern void send_connection_state_to_app(const char *address);
+extern void send_playback_state_to_app(void);
 extern char * get_ip_str(const struct sockaddr *sa);
 #else
 const char *logtime(void);


### PR DESCRIPTION
Three independent changes, one commit each, reviewed separately before being brought together here. Each links to a PR on my fork carrying the full reasoning, the captured logs and the device testing — this description is the summary.

## 1. Auto-start on the A2DP connection, not on the radio link

[Detail](https://github.com/werdeil/squeezelite/pull/4)

`CommandReceiver` listened for `ACL_CONNECTED` / `ACL_DISCONNECTED`, which say a Bluetooth *radio link* came or went rather than that an audio device became usable. Putting earbuds back in their case flaps that link, and every re-connection restarted the player, which reconnected to LMS and resumed the playlist — so the music came back after being deliberately stopped.

It now listens for `BluetoothA2dp.ACTION_CONNECTION_STATE_CHANGED`, which is on the same documented exemption list for implicit broadcasts as the two ACL actions it replaces. The earbuds also briefly re-establish the A2DP profile itself, so a connection arriving less than 5 s after a disconnection of a configured device is ignored.

## 2. Always create the JSON-RPC connection, and report request failures

[Detail](https://github.com/werdeil/squeezelite/pull/2)

`jsonRpc` was only created when volume control was set to "synchronized", but `sendCommand()` — the path behind play/pause, next and previous from a Bluetooth device, headset or the notification — is a silent no-op when it is null. So with volume control on "separate" or "device", media buttons did nothing, with nothing in the log to say why. `client forget` on stop stays conditional on the synchronized mode.

Separately, `JsonRpc.Request` was built with a null error listener, so a failed request never called its listener back. That matters on shutdown, where `stopPlayer()` calls `System.exit(0)` from the response listener of `client forget`.

**One consequence worth your attention:** two call sites guarded by `null!=jsonRpc` are now reached in the "separate" and "device" modes. `power 1` is sent, which looks intended. But `playerpref maxBitrate 0` is also sent on ordinary Wi-Fi with default settings, which clears any bitrate limit set on the LMS side — because of an operator precedence quirk at `Library.java:127-133` that I deliberately left alone, since fixing it would change the default mode's behaviour too. The synchronized mode has always done this; the change is that the other two now do as well. Happy to handle it differently if you would rather.

## 3. Send current track details to connected devices

[Detail](https://github.com/werdeil/squeezelite/pull/1)

The `MediaSession` was only used to *receive* commands. This publishes into it as well, so a Bluetooth car stereo or headset (AVRCP), a Wear OS watch, Android Auto and the lock screen can show what is playing. A new `send_playback_state_to_app()` JNI callback fires when a track starts — hooked on `STMs` rather than `strm s`, since with gapless playback LMS sends `strm s` for the next track while the current one still plays — and on pause, resume and stop. A new `NowPlaying` class then reads the player status and publishes the details, artwork and playback state. Webradios have no track change to react to, so they are polled every 30 s while playing.

Activating the session opens the framework's own media button dispatch, which exposed a dormant bug: `onMediaButtonEvent` acted on `ACTION_UP`, letting `ACTION_DOWN` also reach the transport callbacks, so every press sent its command twice — and as `pause` with no argument toggles, pressing pause paused and immediately resumed. It now acts on `ACTION_DOWN` and consumes the event. `MEDIA_PLAY` / `MEDIA_PAUSE` send explicit `pause 0` / `pause 1`, `HEADSETHOOK` and `MEDIA_STOP` are now handled, and `onSeekTo` and `onStop` are implemented.

Behind a new **"Send track details"** setting, on by default (English and French strings added). With it off, the session is never activated and no status is read, so the previous behaviour is restored.

## Testing

All three were verified on a Pixel 7a against LMS 9. On a Pixel Watch 4 the third change is a clear improvement: playback control from the watch works again, and the album art shows as the background.

**Not verified: the display on an actual car stereo** — no device available. The session is demonstrably fed correctly, but that does not prove Android relays it over AVRCP. Album art most likely will not reach one in any case: standard AVRCP metadata carries text only, and cover art needs AVRCP 1.6 with BIP/OBEX.

## Notes

**Two files outside `android/` are touched by the third commit:** `slimproto.c` (17 lines) and `squeezelite.h` (1 line), entirely inside `#ifdef ANDROID`. Nothing changes for a non-Android build, but say the word if you would rather see it placed differently.

**`android/app/CMakeLists.txt` declares no dependency on the C sources**, so an existing `libsqueezelite.so` is never rebuilt — `android/clean.sh` is needed when switching to this branch, or the native library and the Java can silently disagree.
