### PR TITLE
fix: Fix multi-room sync

### DIFF
--- a/android/app/CMakeLists.txt
+++ b/android/app/CMakeLists.txt
@@ -14,9 +14,19 @@ endif()
 
 file(MAKE_DIRECTORY ${CMAKE_SOURCE_DIR}/../build/)
 
+file(GLOB_RECURSE SL_NATIVE_SOURCES
+    ${CMAKE_SOURCE_DIR}/../src/*.c
+    ${CMAKE_SOURCE_DIR}/../src/*.cpp
+    ${CMAKE_SOURCE_DIR}/../src/*.h
+    ${CMAKE_SOURCE_DIR}/../../*.c
+    ${CMAKE_SOURCE_DIR}/../../*.cpp
+    ${CMAKE_SOURCE_DIR}/../../*.h
+    ${CMAKE_SOURCE_DIR}/../meson.build)
+
 add_custom_command(
     OUTPUT ${CMAKE_SOURCE_DIR}/src/main/jniLibs/${CMAKE_ANDROID_ARCH_ABI}/libsqueezelite.so
     COMMAND python3 ../build.py ${SDK_ROOT} ${NDK_HOME} ${CMAKE_ANDROID_ARCH_ABI} --buildtype=release -Db_ndebug=true -Dwrap_mode=forcefallback
+    DEPENDS ${SL_NATIVE_SOURCES}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/../build/
 )
 

--- a/android/src/pa/hostapi/aaudio/libaaudio.c
+++ b/android/src/pa/hostapi/aaudio/libaaudio.c
@@ -30,6 +30,8 @@ typedef void    (*signature_V_PBPDPV)(AAudioStreamBuilder *, AAudioStream_dataCa
 typedef void    (*signature_V_PBPEPV)(AAudioStreamBuilder *, AAudioStream_errorCallback, void *);
 typedef int32_t (*signature_I_PBPPS)(AAudioStreamBuilder *, AAudioStream **stream);
 typedef int32_t (*signature_I_PB)(AAudioStreamBuilder *);
+typedef int32_t (*signature_I_PSCPQPQP)(AAudioStream *, clockid_t, int64_t *, int64_t *);
+typedef int32_t (*signature_I_PSPL)(AAudioStream *, int64_t *);
 
 static signature_I_PPB     AAudio_createStreamBuilder_ptr = NULL;
 static signature_I_PS      AAudioStream_close_ptr = NULL;
@@ -48,6 +50,12 @@ static signature_V_PBPEPV  AAudioStreamBuilder_setErrorCallback_ptr = NULL;
 static signature_V_PBI     AAudioStreamBuilder_setFormat_ptr = NULL;
 static signature_I_PBPPS   AAudioStreamBuilder_openStream_ptr = NULL;
 static signature_I_PB      AAudioStreamBuilder_delete_ptr = NULL;
+/* Optional (API 26+) */
+static signature_I_PSCPQPQP AAudioStream_getTimestamp_ptr = NULL;
+static signature_I_PSPL     AAudioStream_getFramesRead_ptr = NULL;
+static signature_I_PSPL     AAudioStream_getTimeNanos_ptr = NULL;
+/* Optional (API 26+) */
+static signature_I_PS       AAudioStream_getFramesPerBurst_ptr = NULL;
 
 static signature_I_PPB load_signature_I_PPB(void *lib, char *name) {
     return (signature_I_PPB)dlsym(lib, name);
@@ -75,6 +83,12 @@ static signature_I_PBPPS load_signature_I_PBPPS(void *lib, char *name) {
 }
 static signature_I_PB load_signature_I_PB(void *lib, char *name) {
     return (signature_I_PB)dlsym(lib, name);
+}
+static signature_I_PSCPQPQP load_signature_I_PSCPQPQP(void *lib, char *name) {
+    return (signature_I_PSCPQPQP)dlsym(lib, name);
+}
+static signature_I_PSPL load_signature_I_PSPL(void *lib, char *name) {
+    return (signature_I_PSPL)dlsym(lib, name);
 }
 
 int LibAAudio_init() {
@@ -151,7 +165,41 @@ int LibAAudio_init() {
     if (!AAudioStreamBuilder_delete_ptr) {
         return 0;
     }
+    /* Optional: API 26+. */
+    AAudioStream_getTimestamp_ptr = (signature_I_PSCPQPQP)dlsym(aalib, "AAudioStream_getTimestamp");
+    AAudioStream_getFramesRead_ptr = (signature_I_PSPL)dlsym(aalib, "AAudioStream_getFramesRead");
+    AAudioStream_getTimeNanos_ptr = (signature_I_PSPL)dlsym(aalib, "AAudioStream_getTimeNanos");
+    AAudioStream_getFramesPerBurst_ptr = (signature_I_PS)dlsym(aalib, "AAudioStream_getFramesPerBurst");
     return 1;
+}
+
+int LibAAudio_HasTimestamp() {
+    return NULL != AAudioStream_getTimestamp_ptr;
+}
+
+aaudio_result_t LibAAudioStream_getTimestamp(AAudioStream* stream, clockid_t clockId, int64_t* framePosition, int64_t* timeNanoseconds) {
+    return AAudioStream_getTimestamp_ptr
+        ? (*AAudioStream_getTimestamp_ptr)(stream, clockId, framePosition, timeNanoseconds)
+        : AAUDIO_ERROR_NULL;
+}
+
+aaudio_result_t LibAAudioStream_getFramesRead(AAudioStream* stream, int64_t* frames) {
+    return AAudioStream_getFramesRead_ptr
+        ? (*AAudioStream_getFramesRead_ptr)(stream, frames)
+        : AAUDIO_ERROR_NULL;
+}
+
+aaudio_result_t LibAAudioStream_getTimeNanos(AAudioStream* stream, int64_t* nanoseconds) {
+    return AAudioStream_getTimeNanos_ptr
+        ? (*AAudioStream_getTimeNanos_ptr)(stream, nanoseconds)
+        : AAUDIO_ERROR_NULL;
+}
+
+/* Actual frames-per-burst, or -1 when unavailable. */
+int32_t LibAAudioStream_getFramesPerBurst(AAudioStream* stream) {
+    return AAudioStream_getFramesPerBurst_ptr
+        ? (*AAudioStream_getFramesPerBurst_ptr)(stream)
+        : -1;
 }
 
 aaudio_result_t LibAAudio_createStreamBuilder(AAudioStreamBuilder** builder) {

--- a/android/src/pa/hostapi/aaudio/libaaudio.h
+++ b/android/src/pa/hostapi/aaudio/libaaudio.h
@@ -2,6 +2,7 @@
 #define _LIBAAUDIO_H
 
 #include <aaudio/AAudio.h>
+#include <time.h>
 
 int LibAAudio_init();
 aaudio_result_t LibAAudio_createStreamBuilder(AAudioStreamBuilder** builder);
@@ -21,5 +22,12 @@ void LibAAudioStreamBuilder_setErrorCallback(AAudioStreamBuilder* builder, AAudi
 void LibAAudioStreamBuilder_setFormat(AAudioStreamBuilder* builder, aaudio_format_t format);
 aaudio_result_t LibAAudioStreamBuilder_openStream(AAudioStreamBuilder* builder, AAudioStream** stream);
 aaudio_result_t LibAAudioStreamBuilder_delete(AAudioStreamBuilder* builder);
+/* Optional (API 26+); returns 0 only if available and successful. */
+int LibAAudio_HasTimestamp();
+aaudio_result_t LibAAudioStream_getTimestamp(AAudioStream* stream, clockid_t clockId, int64_t* framePosition, int64_t* timeNanoseconds);
+aaudio_result_t LibAAudioStream_getFramesRead(AAudioStream* stream, int64_t* frames);
+aaudio_result_t LibAAudioStream_getTimeNanos(AAudioStream* stream, int64_t* nanoseconds);
+/* Actual frames-per-burst, or -1 when unavailable. */
+int32_t LibAAudioStream_getFramesPerBurst(AAudioStream* stream);
 
 #endif

--- a/android/src/pa/hostapi/aaudio/pa_aaudio.c
+++ b/android/src/pa/hostapi/aaudio/pa_aaudio.c
@@ -48,8 +48,10 @@
 
 #include <android/log.h>
 #include <android/api-level.h>
+#include <math.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include "libaaudio.h"
 #include "pa_util.h"
 #include "pa_allocation.h"
@@ -105,6 +107,22 @@ typedef struct {
     int bytesPerSample;
     int channelCount;
     aaudio_format_t format;
+    /* Total frames submitted to the device since start. */
+    int64_t framesSubmitted;
+    /* Position estimator: the HAL timestamp pair only refreshes every
+     * ~100ms while callbacks arrive more often, so most callbacks see a
+     * stale pair. We anchor on each fresh pair and extrapolate on our own
+     * CLOCK_MONOTONIC between refreshes. halToOurNs is the HAL-to-local
+     * clock offset, tracked as a running minimum of observed read-lag. */
+    double anchorPos;
+    double anchorOurS;
+    int anchorValid;
+    double slopeHz;
+    int64_t prevPairPos;
+    int64_t prevPairNs;
+    int prevPairValid;
+    int64_t halToOurNs;
+    int halToOurValid;
 } PaAAStream;
 
 typedef struct {
@@ -234,11 +252,135 @@ static PaError IsInputChannelCountSupported(PaAAudioHostApiRepresentation *hostA
     return paNoError;
 }
 
+/* Fill timeInfo so that consumers can derive the device queue depth:
+ *   device_frames = (outputBufferDacTime - currentTime) * sampleRate
+ * AAudioStream_getTimestamp gives frames played and when; combined with
+ * framesSubmitted this yields the queued depth. If the timestamp is
+ * unavailable (pre-API-26, route changes), fall back to getFramesRead,
+ * then to a zeroed timeInfo. */
+static void FillTimeInfo(PaAAudioStream *aaudioStream, AAudioStream *stream,
+                         int32_t numFrames, PaStreamCallbackTimeInfo *timeInfo) {
+    static const double NS_PER_S = 1000000000.0;
+    static int cbCount = 0;
+    int src = 0; /* 0=none 1=timestamp 2=framesRead */
+    int64_t framePosition = 0;
+    int64_t timeNanos = 0;
+    double sampleRate = aaudioStream->streamRepresentation.streamInfo.sampleRate;
+
+    if (sampleRate <= 0) {
+        return;
+    }
+
+    aaudioStream->output.framesSubmitted += numFrames;
+
+    if (LibAAudio_HasTimestamp() &&
+        LibAAudioStream_getTimestamp(stream, CLOCK_MONOTONIC,
+                                     &framePosition, &timeNanos) == AAUDIO_OK &&
+        framePosition >= 0) {
+        src = 1;
+    } else if (LibAAudioStream_getFramesRead(stream, &framePosition) == AAUDIO_OK &&
+               LibAAudioStream_getTimeNanos(stream, &timeNanos) == AAUDIO_OK &&
+               framePosition >= 0) {
+        src = 2;
+    } else {
+        src = 0;
+    }
+
+    if (0 != src) {
+        double rawQueued = (double)(aaudioStream->output.framesSubmitted) - (double)framePosition;
+        if (rawQueued < 0) {
+            rawQueued = 0; /* timestamp raced/reset */
+        }
+
+        /* Anchor on fresh pairs, extrapolate between them on our own
+         * clock. Never advance on fabricated time. */
+        struct timespec ts;
+        clock_gettime(CLOCK_MONOTONIC, &ts);
+        double ourS = (double)ts.tv_sec + (double)ts.tv_nsec / NS_PER_S;
+        int64_t ourNs = (int64_t)ts.tv_sec * 1000000000LL + ts.tv_nsec;
+        int pairFresh = !aaudioStream->output.prevPairValid ||
+                        framePosition != aaudioStream->output.prevPairPos ||
+                        timeNanos != aaudioStream->output.prevPairNs;
+
+        /* Observed read-lag = offset + pair age (age >= 0), so the true
+         * offset is a lower bound of every observation. */
+        int64_t lagNs = ourNs - timeNanos;
+        if (!aaudioStream->output.halToOurValid || lagNs < aaudioStream->output.halToOurNs) {
+            aaudioStream->output.halToOurNs = lagNs;
+            aaudioStream->output.halToOurValid = 1;
+        }
+        if (pairFresh) {
+            /* Consumption rate since the previous fresh pair. Require the
+             * position to advance so a time-only refresh cannot zero the
+             * slope. */
+            if (aaudioStream->output.prevPairValid &&
+                framePosition > aaudioStream->output.prevPairPos &&
+                timeNanos > aaudioStream->output.prevPairNs + 100000000LL /*100ms*/) {
+                double s = (double)(framePosition - aaudioStream->output.prevPairPos) *
+                           NS_PER_S / (double)(timeNanos - aaudioStream->output.prevPairNs);
+                /* Clamp so a bad pair can skew at most one window. */
+                if (s > sampleRate * 1.1) s = sampleRate * 1.1;
+                if (s < sampleRate * 0.9) s = sampleRate * 0.9;
+                aaudioStream->output.slopeHz = s;
+            }
+            aaudioStream->output.prevPairPos = framePosition;
+            aaudioStream->output.prevPairNs = timeNanos;
+            aaudioStream->output.prevPairValid = 1;
+            /* Anchor at the pair's capture instant in our time base. */
+            aaudioStream->output.anchorPos = (double)framePosition;
+            aaudioStream->output.anchorOurS =
+                ((double)timeNanos + (double)aaudioStream->output.halToOurNs) / NS_PER_S;
+            if (!aaudioStream->output.anchorValid) {
+                /* Seed the slope until a pair-to-pair interval exists. */
+                aaudioStream->output.slopeHz = sampleRate;
+                aaudioStream->output.anchorValid = 1;
+            }
+        }
+        if (!aaudioStream->output.anchorValid) {
+            return; /* nothing trustworthy yet: keep zeroed timeInfo */
+        }
+        double dt = ourS - aaudioStream->output.anchorOurS;
+        if (dt < 0) dt = 0;
+        double playedEst = aaudioStream->output.anchorPos + dt * aaudioStream->output.slopeHz;
+
+        /* output_pa.c stamps frames_played_dmp at callback start, i.e.
+         * framesSubmitted - numFrames. Report the depth against the same
+         * count so the two cancel in ms_played regardless of burst sizes. */
+        double queuedFrames = (double)(aaudioStream->output.framesSubmitted - numFrames) - playedEst;
+        if (queuedFrames < 0) queuedFrames = 0;
+
+        timeInfo->currentTime = ourS;
+        timeInfo->outputBufferDacTime = ourS + queuedFrames / sampleRate;
+        if ((++cbCount % 250) == 0) {
+            LOGD("syncdbg src=%d submitted=%lld played=%lld queuedMs=%.0f rawMs=%.0f estMs=%.0f slope=%.1f lagMs=%.1f dt=%.3f",
+                 src,
+                 (long long)aaudioStream->output.framesSubmitted,
+                 (long long)framePosition,
+                 1000.0 * queuedFrames / sampleRate,
+                 1000.0 * rawQueued / sampleRate,
+                 1000.0 * playedEst / sampleRate,
+                 aaudioStream->output.slopeHz,
+                 (double)aaudioStream->output.halToOurNs / 1000000.0,
+                 dt);
+        }
+        return;
+    }
+
+    /* No timing source: leave zeroed. */
+    if ((++cbCount % 250) == 0) {
+        LOGD("syncdbg src=0 (no timing source)");
+    }
+}
+
 static aaudio_data_callback_result_t AaudioDataCallback(AAudioStream *stream, void *userData, void *audioData, int32_t numFrames) {
     PaAAudioStream *aaudioStream = (PaAAudioStream *)userData;
     PaStreamCallbackTimeInfo timeInfo = {0, 0, 0};
     int result = paContinue;
     unsigned long framesProcessed = 0;
+
+    if (aaudioStream->output.use) {
+        FillTimeInfo(aaudioStream, stream, numFrames, &timeInfo);
+    }
 
     PaUtil_BeginBufferProcessing(&aaudioStream->bufferProcessor, &timeInfo, aaudioStream->cbFlags);
     PaUtil_SetOutputFrameCount(&aaudioStream->bufferProcessor, numFrames);
@@ -299,6 +441,12 @@ static PaError StartStream(PaStream *s) {
     PaUtil_ResetBufferProcessor(&aaudioStream->bufferProcessor);
     aaudioStream->isStopped = 0;
     aaudioStream->isActive = 1;
+    /* Queued-depth bookkeeping starts fresh with the stream. */
+    aaudioStream->output.framesSubmitted = 0;
+    aaudioStream->output.anchorValid = 0;
+    aaudioStream->output.prevPairValid = 0;
+    aaudioStream->output.halToOurValid = 0;
+    aaudioStream->output.slopeHz = 0;
     if (aaudioStream->output.use && aaudioStream->output.stream && LibAAudioStream_requestStart(aaudioStream->output.stream) != AAUDIO_OK) {
         return paUnanticipatedHostError;
     }
@@ -449,13 +597,9 @@ static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi, PaStream 
                                           streamCallback, userData);
     PaUtil_InitializeCpuLoadMeasurer(&aaudioStream->cpuLoadMeasurer, sampleRate);
 
-    result = PaUtil_InitializeBufferProcessor(&aaudioStream->bufferProcessor, inputChannelCount, inputSampleFormat,
-                                              hostInputSampleFormat, outputChannelCount, outputSampleFormat,
-                                              hostOutputSampleFormat, sampleRate, streamFlags, framesPerBuffer,
-                                              framesPerHostBuffer, paUtilFixedHostBufferSize, streamCallback, userData);
-    if (result != paNoError) {
-        goto error;
-    }
+    /* The buffer processor is initialized below, after the streams are
+     * opened, so the user/host buffer sizes can follow the actual
+     * frames-per-burst. */
 
     aaudioStream->streamRepresentation.streamInfo.sampleRate = sampleRate;
     aaudioStream->framesPerHostCallback = framesPerHostBuffer;
@@ -497,6 +641,9 @@ static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi, PaStream 
             goto error;
         }
         LibAAudioStreamBuilder_delete(builder);
+        LOGD("syncdbg open: framesPerBuffer=%lu hostCalc=%lu burst=%d",
+             framesPerBuffer, framesPerHostBuffer,
+             LibAAudioStream_getFramesPerBurst(aaudioStream->output.stream));
     }
 
     // Input stream setup
@@ -523,6 +670,29 @@ static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi, PaStream 
             result = paUnanticipatedHostError; goto error;
         }
         LibAAudioStreamBuilder_delete(builder);
+    }
+
+    /* When no buffer size was requested, use one user callback per AAudio
+     * callback so the buffer processor does not split host callbacks. */
+    {
+        unsigned long userFrames = framesPerBuffer;
+        unsigned long hostFrames = framesPerHostBuffer;
+        if (userFrames == paFramesPerBufferUnspecified && aaudioStream->output.use) {
+            int32_t burst = aaudioStream->output.stream
+                ? LibAAudioStream_getFramesPerBurst(aaudioStream->output.stream) : -1;
+            if (burst > 0) {
+                userFrames = (unsigned long)burst;
+                hostFrames = (unsigned long)burst;
+            }
+        }
+        result = PaUtil_InitializeBufferProcessor(&aaudioStream->bufferProcessor, inputChannelCount, inputSampleFormat,
+                                                  hostInputSampleFormat, outputChannelCount, outputSampleFormat,
+                                                  hostOutputSampleFormat, sampleRate, streamFlags, userFrames,
+                                                  hostFrames, paUtilFixedHostBufferSize, streamCallback, userData);
+        if (result != paNoError) {
+            goto error;
+        }
+        aaudioStream->framesPerHostCallback = hostFrames;
     }
 
     *s = (PaStream *)aaudioStream;


### PR DESCRIPTION
Here's a draft PR, because it's obviously LLM-generated code (GLM-5.3)
I've (for now?) left in its verbose comments, as they might be helpful and I'm still decoding which of them are necessary.

Feel free to close without comment.

___

The motivation here was that syncing squeezelite running on my echo show 5 gen1 running lineageOS 18.1 to my squeezebox classic v3 simply did not work. It did sync up, then it drifted apart over the course of a few seconds, then it synced up again.
Quite the miserable audio experience.

With this PR (and a static offset in the LMS), things now play in sync consistently (at least during my limited 1h testing).


My high-level understanding of the problem is that a feedback mechanism between the hardware playing audio and the application was broken/not implemented, which led to audio drfting apart.
Clanker says that this might've been an artifact of porting from the OpenSL ES backend.

In its words:
1. PaStreamCallbackTimeInfo was never filled.
2. Host callbacks were split into 88-frame user callbacks. 

Which is what the code aims to fix.

__

I now have an APK that does the thing I want it to - and slimproto and all is stable, so it will keep running - meaning that absolutely no pressure from my side here. As said, if you're not up for LLM nonsense, just close with no comment.

I just figured that it might make sense to raise this.