### PR TITLE
fix: Fix squeezelite process dying unexpectedly

### DIFF
--- a/android/src/pa/hostapi/aaudio/pa_aaudio.c
+++ b/android/src/pa/hostapi/aaudio/pa_aaudio.c
@@ -260,7 +260,9 @@ static aaudio_data_callback_result_t AaudioDataCallback(AAudioStream *stream, vo
         if( aaudioStream->streamRepresentation.streamFinishedCallback != NULL ) {
             aaudioStream->streamRepresentation.streamFinishedCallback( aaudioStream->streamRepresentation.userData );
         }
-        return AAUDIO_CALLBACK_RESULT_STOP;
+        // Returning STOP races the AAudioStream_close() that follows the finished
+        // callback, and can deadlock inside AAudio. The app stops the stream.
+        return AAUDIO_CALLBACK_RESULT_CONTINUE;
     }
     return AAUDIO_CALLBACK_RESULT_CONTINUE;
 }

--- a/output_pa.c
+++ b/output_pa.c
@@ -338,9 +338,16 @@ void _pa_open(void) {
 
 #endif
 	if (pa.stream) {
-		if ((err = Pa_CloseStream(pa.stream)) != paNoError) {
+		PaStream *old_stream = pa.stream;
+		pa.stream = NULL;
+
+		// Pa_CloseStream can wait for an in-flight data callback, which needs this
+		// mutex - so never close the stream while holding it
+		UNLOCK;
+		if ((err = Pa_CloseStream(old_stream)) != paNoError) {
 			LOG_WARN("error closing stream: %s", Pa_GetErrorText(err));
 		}
+		LOCK;
 	}
 
 	if (output.state == OUTPUT_OFF) {


### PR DESCRIPTION
Same disclaimers as in #32 apply.

While playing around with home assistant's TTS notifications, I've noticed that the player would occasionally vanish from the LMS while the app still claimed that it was running.

The clanker (GLM-5.3) discovered two race conditions.
I would probably remove those comments, but, again, I lack the insight into multimedia.

It does do the thing tho