### PR TITLE
fix: Fix single channel only setting not being respected

### DIFF
--- a/output_pa.c
+++ b/output_pa.c
@@ -471,7 +471,7 @@ static int _write_frames(frames_t out_frames, bool silence, s32_t gainL, s32_t g
 			_apply_cross(outputbuf, out_frames, cross_gain_in, cross_gain_out, cross_ptr);
 		}
 		
-		if (gainL != FIXED_ONE || gainR!= FIXED_ONE) {
+		if (gainL != FIXED_ONE || gainR != FIXED_ONE || (flags & (MONO_LEFT | MONO_RIGHT))) {
 			_apply_gain(outputbuf, out_frames, gainL, gainR, flags);
 		}
 


### PR DESCRIPTION
Now that I have 2 Echo Show 5 Gen1, I could play around with more sync options.

Specifically, this one:
<img width="514" height="87" alt="image" src="https://github.com/user-attachments/assets/a815e0f7-8dfb-4124-928d-c5e7dc4e5b43" />


It didn't work. Now it does